### PR TITLE
Fix hyperlinks inside of table cells

### DIFF
--- a/src/PhpPowerpoint/Writer/PowerPoint2007/Rels.php
+++ b/src/PhpPowerpoint/Writer/PowerPoint2007/Rels.php
@@ -327,8 +327,24 @@ class Rels extends AbstractPart
                 }
 
                 // Hyperlink on rich text run
-                if ($iterator->current() instanceof RichText) {
-                    foreach ($iterator->current()->getParagraphs() as $paragraph) {
+                if ($iterator->current() instanceof PHPPowerPoint_Shape_RichText ||
+                    $iterator->current() instanceof PHPPowerPoint_Shape_Table
+                ) {
+                    if ($iterator->current() instanceof PHPPowerPoint_Shape_Table) {
+                        // Table cells can have hyperlinks too
+                        // coalesce all paragraphs in all cells
+                        $paragraphs = array();
+                        $rows = $iterator->current()->getRows();
+                        foreach ($rows as $row) {
+                            $cells = $row->getCells();
+                            foreach ($cells as $cell) {
+                                $paragraphs = array_merge($paragraphs, array_values($cell->getParagraphs()));
+                            }
+                        }
+                    } else {
+                        $paragraphs = $iterator->current()->getParagraphs();
+                    }
+                    foreach ($paragraphs as $paragraph) {
                         foreach ($paragraph->getRichTextElements() as $element) {
                             if ($element instanceof Run || $element instanceof TextElement) {
                                 if ($element->hasHyperlink()) {


### PR DESCRIPTION
This patch fixes a bug where a Hyperlink added to a Paragraph inside of
a Table Cell wasn't getting added to the Rels as well as getting
assigned a null id when being output as PowerPoint2007.

What this patch does is when adding Hyperlinks to the Rels, it also
iterates over Paragraphs inside of Table Cells as if they were inside of
a normal RichText shape.